### PR TITLE
fix: variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ describe('your test', () => {
   });
 
   afterEach(() => {
-    matchMedia.clear();
+    matchMediaMock.clear();
   });
 
   afterAll(() => {


### PR DESCRIPTION
Fix variable name `matchMedia` -> `matchMediaMock` in README