### PR TITLE
Call change events always but with appropriate matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,24 @@ describe('your test', () => {
 
 ## Use Media Query
 
+### Example implementation
+
+```typescript
+export const myImplementation = () => {
+  const myMediaMatcher = window.matchMedia('(prefers-color-scheme: dark)');
+  myMediaMatcher.addEventListener('change', (ev) => {
+    console.log(ev.matches);
+  });
+
+  return myMediaMatcher.matches;
+};
+```
+
+### Test
+
 ```typescript
 describe('your test', () => {
   let matchMediaMock = new MatchMediaMock();
-  beforeAll(() => {
-    matchMediaMock.useMediaQuery('(prefers-color-scheme: dark)');
-  });
 
   afterEach(() => {
     matchMediaMock.clear();
@@ -37,8 +49,37 @@ describe('your test', () => {
   afterAll(() => {
     matchMediaMock.destroy();
   });
+
+  test('matches immediately', () => {
+    matchMediaMock.useMediaQuery('(prefers-color-scheme: dark)');
+    const response = myImplementation();
+
+    expect(response).toBe(true);
+  });
+
+  test('doesnt match immediately', () => {
+    matchMediaMock.useMediaQuery('(prefers-color-scheme: light)');
+    const response = myImplementation();
+
+    expect(response).toBe(false);
+  });
+
+  test('fires change event with match', () => {
+    myImplementation();
+    matchMediaMock.useMediaQuery('(prefers-color-scheme: dark)');
+
+    expect(console.log).toHaveBeenCalledWith(true);
+  });
+
+  test('fires change event with mismatch', () => {
+    myImplementation();
+    matchMediaMock.useMediaQuery('(prefers-color-scheme: light)');
+
+    expect(console.log).toHaveBeenCalledWith(false);
+  });
 });
 ```
+
 [npm-downloads-url]: https://npmcharts.com/compare/vitest-matchmedia-mock?minimal=true
 [npm-downloads-image]: https://badgen.net/npm/dm/vitest-matchmedia-mock
 [npm-version-image]: https://badgen.net/npm/v/vitest-matchmedia-mock

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -120,19 +120,60 @@ describe('MatchMedia Mock', () => {
       expect(window.matchMedia(appearanceMq.light).matches).toBeTruthy();
     });
 
-    test('calls listener functions when applying a media query with previously registered listeners', () => {
-      const firstListener = vi.fn<any[]>();
-      const secondListener = vi.fn<any[]>();
+    test('calls listener functions when applying a media query with previously registered listeners if they match', () => {
+      const firstListener = vi.fn();
+      const secondListener = vi.fn();
 
       const mql = window.matchMedia(appearanceMq.light);
 
-      mql.addListener((ev) => ev.matches && firstListener());
-      mql.addListener((ev) => ev.matches && secondListener());
+      mql.addEventListener<'change'>('change', firstListener);
+      mql.addEventListener<'change'>('change', secondListener);
 
       matchMedia.useMediaQuery(appearanceMq.light);
 
       expect(firstListener).toBeCalledTimes(1);
       expect(secondListener).toBeCalledTimes(1);
+    });
+
+    test('calls listener functions when applying a media query with previously registered listeners if they dont match', () => {
+      const firstListener = vi.fn();
+      const secondListener = vi.fn();
+
+      const mql = window.matchMedia(appearanceMq.light);
+
+      mql.addEventListener<'change'>('change', firstListener);
+      mql.addEventListener<'change'>('change', secondListener);
+
+      matchMedia.useMediaQuery(appearanceMq.dark);
+
+      expect(firstListener).toBeCalledTimes(1);
+      expect(secondListener).toBeCalledTimes(1);
+    });
+
+    test('changes `matches` state to true if a subsequent change does match', () => {
+      const firstListener = vi.fn();
+
+      const mql = window.matchMedia(appearanceMq.light);
+
+      mql.addEventListener<'change'>('change', firstListener);
+
+      matchMedia.useMediaQuery(appearanceMq.light);
+
+      expect(firstListener).toBeCalledTimes(1);
+      expect(window.matchMedia(appearanceMq.light).matches).toBeTruthy();
+    });
+
+    test('changes `matches` state to false if a subsequent change doesnt match', () => {
+      const firstListener = vi.fn();
+
+      const mql = window.matchMedia(appearanceMq.light);
+
+      mql.addEventListener<'change'>('change', firstListener);
+
+      matchMedia.useMediaQuery(appearanceMq.dark);
+
+      expect(firstListener).toBeCalledTimes(1);
+      expect(window.matchMedia(appearanceMq.light).matches).not.toBeTruthy();
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1291,10 +1291,11 @@
       "dev": true
     },
     "node_modules/@vitest/coverage-c8/node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -1325,9 +1326,9 @@
       }
     },
     "node_modules/@vitest/coverage-c8/node_modules/vite": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
-      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1980,10 +1981,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2735,15 +2737,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4583,9 +4586,9 @@
           "dev": true
         },
         "rollup": {
-          "version": "3.29.4",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-          "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+          "version": "3.29.5",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+          "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
           "dev": true,
           "requires": {
             "fsevents": "~2.3.2"
@@ -4604,9 +4607,9 @@
           "dev": true
         },
         "vite": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
-          "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+          "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
           "dev": true,
           "requires": {
             "esbuild": "^0.18.10",
@@ -5046,9 +5049,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -5616,9 +5619,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
     },
     "nwsapi": {
       "version": "2.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-matchmedia-mock",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "mocking window.matchmedia with vitest",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,15 +111,22 @@ export default class MatchMediaMock {
 
     this.currentMediaQuery = mediaQuery;
 
-    if (!this.mediaQueries[mediaQuery]) return;
+    if (!Object.entries(this.mediaQueries).length) return;
 
-    const mqListEvent: Partial<MediaQueryListEvent> = {
-      matches: true,
-      media: mediaQuery,
-    };
+    const mqListEvent: Partial<MediaQueryListEvent> = this.mediaQueries[mediaQuery]
+      ? {
+          matches: true,
+          media: mediaQuery,
+        }
+      : {
+          matches: false,
+          media: mediaQuery,
+        };
 
-    this.mediaQueries[mediaQuery].forEach((listener) => {
-      listener.call(this.mediaQueryList, mqListEvent as MediaQueryListEvent);
+    Object.entries(this.mediaQueries).forEach(([_, value]) => {
+      value.forEach((listener) => {
+        listener.call(this.mediaQueryList, mqListEvent as MediaQueryListEvent);
+      });
     });
   }
 


### PR DESCRIPTION
The following changes have been requested in this PR:

1. Calling the change event listeners on **any** call to `useMediaQuery`
2. Comparing queries to decide whether `matches:true` or `matches:false`
3. Added tests
4. Updated documentation
5. Bumped version to 2.0.0 (Although none of the original tests fail, I think it merits a breaking change as many people may have worked around the issue by asserting on a lack of event, or an undefined value) 